### PR TITLE
SDL: use system format for audio, fixes audio cracks on big-endian systems

### DIFF
--- a/src/Backends/Audio/SoftwareMixer/SDL2.cpp
+++ b/src/Backends/Audio/SoftwareMixer/SDL2.cpp
@@ -66,7 +66,7 @@ unsigned long SoftwareMixerBackend_Init(void (*callback)(long *stream, size_t fr
 
 	SDL_AudioSpec specification;
 	specification.freq = 48000;
-	specification.format = AUDIO_S16;
+	specification.format = AUDIO_S16SYS;
 	specification.channels = 2;
 	specification.samples = 0x400;	// Roughly 10 milliseconds for 48000Hz
 	specification.callback = Callback;


### PR DESCRIPTION
Doing this change because on big-endian devices there's crack noises, AUDIO_S16SYS is native byte order and works regardless endianness.

Best regards,
Link.